### PR TITLE
Fix restore from dump in tests.

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,21 +14,22 @@
 
 from .util import Environment
 
-from unittest.mock import patch
 
 import os
+import pytest
 
 
 class TestInstall:
     def verify_install(self, env: Environment, bark_cli, passes: bool):
         cwd = os.getcwd()
         os.chdir(env.repo.repo_dir)
-        with patch("click.confirm", return_value="y"):
-            result = bark_cli("install")
-        if passes:
-            assert result.exit_code == 0
+        print(env.repo.repo_dir)
+
+        if not passes:
+            with pytest.raises(SystemExit):
+                bark_cli("install", input="y")
         else:
-            assert result.exit_code != 0
+            bark_cli("install", input="y")
         os.chdir(cwd)
 
     def test_install_without_bark_rules(self, env_clean: Environment, bark_cli):

--- a/tests/util.py
+++ b/tests/util.py
@@ -30,11 +30,6 @@ import yaml
 import os
 
 
-def get_test_bark_module():
-    cwd = os.getcwd()
-    return os.path.join(cwd, "tests", "test_bark_module")
-
-
 def random_string(length: int = 10):
     # choose from all lowercase letter
     letters = string.ascii_lowercase
@@ -192,6 +187,14 @@ class Environment:
     def restore_from_dump(self, dump: str) -> None:
         dump_repo_path = os.path.join(dump, "repo")
         dump_remote_path = os.path.join(dump, "remote")
+
+        # Recreating the folders to ensure all files and folders
+        # are copied.
+        shutil.rmtree(self.repo_dir)
+        shutil.rmtree(self.remote_dir)
+        os.mkdir(self.repo_dir)
+        os.mkdir(self.remote_dir)
+
         cmd("cp", "-fr", f"{dump_repo_path}/.", f"{self.repo_dir}/")
         cmd("cp", "-fr", f"{dump_remote_path}/.", f"{self.remote_dir}/")
 


### PR DESCRIPTION
Previously, the `.git/bark` folder was not properly synchronized when restoring from dumps. This PR solves this by deleting and re-creating the folders before restoring from dumps. 