### PR TITLE
Refactor refs

### DIFF
--- a/gitbark/cli/__main__.py
+++ b/gitbark/cli/__main__.py
@@ -265,7 +265,6 @@ def main():
         _add_subcommands(cli)
         cli(obj={})
     except Exception as e:
-        raise e
         status = 1
         msg = e.args[0]
         if isinstance(e, CliFail):

--- a/gitbark/cli/__main__.py
+++ b/gitbark/cli/__main__.py
@@ -23,10 +23,10 @@ from gitbark.commands.setup import (
     checkout_or_orphan,
 )
 
-from gitbark.core import BARK_RULES_BRANCH
+from gitbark.core import BARK_RULES_REF
 from gitbark.project import Project
 from gitbark.rule import RuleViolation
-from gitbark.util import cmd
+from gitbark.util import cmd, branch_name
 from gitbark.git import Commit, ReferenceUpdate
 from .util import (
     BarkContextObject,
@@ -40,7 +40,7 @@ from .util import (
 import click
 import logging
 import sys
-from pygit2 import Branch
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -86,15 +86,15 @@ def add_rules(ctx):
 def add_modules(ctx):
     """Add bark modules."""
     project = ctx.obj["project"]
-    curr_branch = cmd("git", "symbolic-ref", "--short", "HEAD")[0]
+    curr_ref = cmd("git", "symbolic-ref", "HEAD")[0]
     add_modules_interactive(project)
     _confirm_commit(
         commit_message="Modify bark modules (made by bark).",
         manual_action=(
-            "The 'bark_rules.yaml' file has been staged. " "Please commit the changes!"
+            "The 'bark_rules.yaml' file has been staged. Please commit the changes!"
         ),
     )
-    checkout_or_orphan(project, curr_branch)
+    checkout_or_orphan(project, curr_ref)
     click.echo("Bark modules configuration was committed successfully!")
 
 
@@ -108,15 +108,15 @@ def protect(ctx):
     automatically.
     """
     project = ctx.obj["project"]
-    curr_branch = cmd("git", "symbolic-ref", "--short", "HEAD")[0]
-    add_branches_interactive(project, curr_branch)
+    curr_ref = cmd("git", "symbolic-ref", "HEAD")[0]
+    add_branches_interactive(project, curr_ref)
     _confirm_commit(
         commit_message="Modify bark modules (made by bark).",
         manual_action=(
             "The 'bark_rules.yaml' file has been staged. " "Please commit the changes!"
         ),
     )
-    checkout_or_orphan(project, curr_branch)
+    checkout_or_orphan(project, curr_ref)
     click.echo("Bark modules configuration was committed successfully!")
 
 
@@ -132,10 +132,10 @@ def install(ctx):
     project = ctx.obj["project"]
 
     repo = project.repo
-    if not repo.lookup_branch(BARK_RULES_BRANCH):
+    if BARK_RULES_REF not in repo.references:
         raise CliFail('Error: The "bark_rules" branch has not been created!')
 
-    root_commit_hash = cmd("git", "rev-list", "--max-parents=0", BARK_RULES_BRANCH)[0]
+    root_commit_hash = cmd("git", "rev-list", "--max-parents=0", BARK_RULES_REF)[0]
     root_commit = Commit(bytes.fromhex(root_commit_hash), repo)
     if root_commit != project.bootstrap:
         click.echo(
@@ -160,25 +160,10 @@ def install(ctx):
 
 
 @click_callback()
-def click_parse_commit_or_branch(ctx, param, val):
-    project = ctx.obj["project"]
-
-    try:
-        commit, ref = project.repo.resolve_refish(val)
-        if commit and not ref:  # val is commit
-            return commit
-        else:
-            return project.repo.branches[ref.shorthand]  # val is a branch
-
-    except KeyError:
-        raise CliFail(f"{val} is not a valid commit or branch!")
-
-
-@click_callback()
 def click_parse_bootstrap(ctx, param, val):
     project = ctx.obj["project"]
     if val:
-        return Commit(val, project.repo)
+        return Commit(bytes.fromhex(val), project.repo)
     return None
 
 
@@ -190,7 +175,7 @@ def click_parse_ref_update(ctx, param, val):
 
 @cli.command()
 @click.pass_context
-@click.argument("target", callback=click_parse_commit_or_branch, default="HEAD")
+@click.argument("target", default="HEAD")
 @click.option(
     "-a",
     "--all",
@@ -225,29 +210,33 @@ def verify(ctx, target, all, bootstrap, ref_update):
     if not is_installed(project):
         raise CliFail("Bark is not installed! Run 'bark install' first!")
 
-    branch = None
     if ref_update:
         if ref_update.ref_name not in project.repo.references:
             return
-        branch = project.repo.references[ref_update.ref_name].shorthand
+        ref = ref_update.ref_name
         head = Commit(bytes.fromhex(ref_update.new_ref), project.repo)
-    elif isinstance(target, Branch):
-        branch = target.shorthand
-        head = Commit(target.target.raw, project.repo)
     else:
-        if not bootstrap:
+        head, ref = project.repo.resolve(target)
+        if not ref and not bootstrap:
             ctx.fail(
                 "verifying a single commit requires specifying a bootstrap with -b"
             )
-        head = Commit(target.id, project.repo)
 
+    fail_head = os.path.join(project.bark_directory, "FAIL_HEAD")
     try:
-        verify_cmd(project, branch, head, bootstrap, all)
+        verify_cmd(project, ref, head, bootstrap, all)
         if all:
             click.echo("Repository is in valid state!")
         elif not ref_update:
-            click.echo(f"{branch} is in a valid state!")
+            if ref:
+                click.echo(f"Branch {branch_name(ref)} is in a valid state!")
+            else:
+                click.echo(f"Commit {head.hash.hex()} is in a valid state!")
+        if os.path.exists(fail_head):
+            os.remove(fail_head)
     except RuleViolation as e:
+        with open(fail_head, "w") as f:
+            f.write(head.hash.hex())
         # TODO: Error message here?
         pp_violation(e)
         sys.exit(1)
@@ -276,6 +265,7 @@ def main():
         _add_subcommands(cli)
         cli(obj={})
     except Exception as e:
+        raise e
         status = 1
         msg = e.args[0]
         if isinstance(e, CliFail):

--- a/gitbark/cli/__main__.py
+++ b/gitbark/cli/__main__.py
@@ -235,8 +235,9 @@ def verify(ctx, target, all, bootstrap, ref_update):
         if os.path.exists(fail_head):
             os.remove(fail_head)
     except RuleViolation as e:
-        with open(fail_head, "w") as f:
-            f.write(head.hash.hex())
+        if ref_update:
+            with open(fail_head, "w") as f:
+                f.write(head.hash.hex())
         # TODO: Error message here?
         pp_violation(e)
         sys.exit(1)

--- a/gitbark/commands/install.py
+++ b/gitbark/commands/install.py
@@ -15,7 +15,7 @@
 from .verify import verify
 from ..project import Project
 from ..util import cmd
-from ..core import BARK_RULES_BRANCH
+from ..core import BARK_RULES_REF
 
 import pkg_resources
 import os
@@ -38,9 +38,7 @@ def bootstrap_verified(project: Project) -> bool:
     bootstrap = project.bootstrap
     if bootstrap:
         try:
-            root_commit = cmd("git", "rev-list", "--max-parents=0", BARK_RULES_BRANCH)[
-                0
-            ]
+            root_commit = cmd("git", "rev-list", "--max-parents=0", BARK_RULES_REF)[0]
             return root_commit == bootstrap.hash.hex()
         except Exception:
             pass  # Fall through

--- a/gitbark/commands/verify.py
+++ b/gitbark/commands/verify.py
@@ -80,15 +80,16 @@ def verify_all(project: Project, bark_rules: BarkRules):
     """Verify all branches matching branch_rules."""
     violations = []
     for ref, head in project.repo.references.items():
-        try:
-            verify_branch(
-                project=project,
-                ref=ref,
-                head=head,
-                bark_rules=bark_rules,
-            )
-        except RuleViolation as e:
-            violations.append(e)
+        if ref.startswith("refs/heads/"):
+            try:
+                verify_branch(
+                    project=project,
+                    ref=ref,
+                    head=head,
+                    bark_rules=bark_rules,
+                )
+            except RuleViolation as e:
+                violations.append(e)
     if violations:
         raise RuleViolation("Not all branches were valid", violations)
 

--- a/gitbark/objects.py
+++ b/gitbark/objects.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .util import branch_name
 from dataclasses import dataclass
 from typing import Union, Any
-from pygit2 import Repository
 import re
 
 
@@ -79,10 +79,6 @@ class BranchRuleData:
     def get_default(cls, pattern: str, bootstrap: bytes) -> "BranchRuleData":
         return cls(pattern=pattern, bootstrap=bootstrap.hex(), rules=[])
 
-    def branches(self, repo: Repository) -> list[str]:
-        pattern = re.compile(self.pattern)
-        return [branch for branch in list(repo.branches.local) if pattern.match(branch)]
-
 
 @dataclass
 class BarkRules:
@@ -96,3 +92,12 @@ class BarkRules:
             raise ValueError("Cannot parse bark_modules.yaml!")
 
         return cls(branches=branches)
+
+    def get_branch_rules(self, ref: str) -> list[BranchRuleData]:
+        branch = branch_name(ref)
+        rules = []
+        for data in self.branches:
+            pattern = re.compile(data.pattern)
+            if pattern.match(branch):
+                rules.append(data)
+        return rules

--- a/gitbark/project.py
+++ b/gitbark/project.py
@@ -118,16 +118,6 @@ class Project:
     def create_env(self) -> None:
         os.makedirs(self.env_path, exist_ok=True)
         cmd(sys.executable, "-m", "venv", self.env_path, cwd=self.path)
-        return
-
-        exec_path = os.path.join(self.env_path, "bin", "python")
-        env_path = cmd(exec_path, "-c", "import sys; print(':'.join(sys.path))")[
-            0
-        ].split(":")
-        additional = [p for p in sys.path[1:] if p not in env_path]
-        env_site = self.get_env_site_packages()
-        with open(os.path.join(env_site, "gitbark.pth"), "w") as f:
-            f.write("\n".join(additional))
 
     def install_modules(self, requirements: bytes) -> None:
         r_file = os.path.join(self.bark_directory, "requirements.txt")
@@ -143,13 +133,7 @@ class Project:
                 f.write(requirements)
 
             pip_path = os.path.join(self.env_path, "bin", "pip")
-            cmd(
-                pip_path,
-                "install",
-                "-r",
-                r_file,
-                env={"PYTHONPATH": ":".join(sys.path)},
-            )
+            cmd(pip_path, "install", "-r", r_file)
 
     def get_env_site_packages(self) -> str:
         exec_path = os.path.join(self.env_path, "bin", "python")

--- a/gitbark/rule.py
+++ b/gitbark/rule.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .git import Commit
+from .git import Commit, Repository
 from .objects import RuleData
 from .project import Cache
 
 from abc import ABC, abstractmethod
-from pygit2 import Repository
 from typing import Any, Optional, ClassVar, Callable, Union
 from importlib.metadata import entry_points
 

--- a/gitbark/util.py
+++ b/gitbark/util.py
@@ -27,3 +27,12 @@ def cmd(*cmd: str, check: bool = True, **kwargs: Any):
             raise e
         else:
             return e.stdout, e.returncode
+
+
+BRANCH_PREFIX = "refs/heads/"
+
+
+def branch_name(ref: str) -> str:
+    if ref.startswith(BRANCH_PREFIX):
+        return ref[len(BRANCH_PREFIX) :]
+    raise ValueError(f"Ref does not describe a branch: '{ref}'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,8 @@
 from gitbark.cli.__main__ import cli, _DefaultFormatter
 from gitbark.cli.util import CliFail
 from gitbark.objects import BranchRuleData, BarkRules
-from gitbark.core import BARK_RULES_BRANCH
+from gitbark.core import BARK_RULES_REF
+from gitbark.util import branch_name
 
 from .util import Environment, disable_bark
 
@@ -83,10 +84,12 @@ def _env_bark_rules_invalid_state(
     env, _ = _env_installed_state
 
     always_fail_rules = {"rules": [{"always_fail": None}]}
-    env.repo.add_commit_rules(commit_rules=always_fail_rules, branch=BARK_RULES_BRANCH)
+    env.repo.add_commit_rules(
+        commit_rules=always_fail_rules, branch=branch_name(BARK_RULES_REF)
+    )
 
     with disable_bark(env.repo) as repo:
-        repo.commit(branch=BARK_RULES_BRANCH)
+        repo.commit(branch=branch_name(BARK_RULES_REF))
 
     dump_path = tmp_path_factory.mktemp("dump")
     env.dump(dump_path)


### PR DESCRIPTION
Add our own Repository class so that pygit2.Repository is only used in gitbark/git.py
Use full refs everywhere except for where branches are needed.

Includes changes from #30 