### PR TITLE
Handle annotated tags and indirect references

### DIFF
--- a/gitbark/git.py
+++ b/gitbark/git.py
@@ -15,7 +15,7 @@
 from .objects import RuleData
 from .util import cmd
 
-from pygit2 import Commit as _Commit, Tree, Repository as _Repository
+from pygit2 import Commit as _Commit, Tree, Repository as _Repository, Tag as _Tag
 from typing import Union, Tuple, Optional
 import yaml
 import re
@@ -72,7 +72,9 @@ class Commit:
         if not isinstance(hash, bytes):
             raise ValueError(f"Commit hash is not bytes {hash}")
         self._object: _Commit = repo._object.get(hash.hex())
-        if not isinstance(self._object, _Commit):
+        if isinstance(self._object, _Tag):
+            self._object = self._object.get_object()
+        if not isinstance(self._object, (_Commit, _Tag)):
             raise ValueError(f"No commit found with hash {hash.hex()}")
 
     @property

--- a/gitbark/git.py
+++ b/gitbark/git.py
@@ -199,7 +199,7 @@ class Repository:
     @property
     def references(self) -> dict[str, Commit]:
         return {
-            ref.name: Commit(ref.target.raw, self)
+            ref.name: Commit(ref.resolve().target.raw, self)
             for ref in self._object.references.iterator()
         }
 


### PR DESCRIPTION
`bark` currently fails when indirect references or annotated tags exist in the repository. For more details, see the commit messages:

- https://github.com/YubicoLabs/gitbark/pull/40/commits/5bd49514f26e01d2596c8ee4b7e189af3d31749a Resolve indirect references in `Repository.references`
- https://github.com/YubicoLabs/gitbark/pull/40/commits/133306e0b932a49ee11f49a79ca76aa270914f81 Resolve tags in `Commit` constructor