### PR TITLE
Show bootstrap commit when asking to confirm

### DIFF
--- a/gitbark/cli/__main__.py
+++ b/gitbark/cli/__main__.py
@@ -46,6 +46,7 @@ from .util import (
 
 import click
 import logging
+import subprocess
 import sys
 import os
 
@@ -61,6 +62,7 @@ def ensure_bootstrap_verified(project: Project) -> None:
                 "WARNING! The previously trusted bootstrap commit has CHANGED!"
             )
     else:
+        subprocess.run(["git", "show", "--stat", root_hash])
         click.echo(
             f"The bootstrap commit ({root_hash}) of the bark_rules "
             "branch has not been verified!"

--- a/gitbark/commands/setup.py
+++ b/gitbark/commands/setup.py
@@ -32,6 +32,7 @@ from typing import Optional
 
 import click
 import os
+import subprocess
 import yaml
 
 ACTIVE_BRANCH = "active_branch"
@@ -237,6 +238,7 @@ def add_branches_interactive(project: Project, branch: str) -> None:
     click.echo(f"Configure how the '{branch}' branch should be validated!\n")
 
     bootstrap = project.repo.resolve(branch)[0].hash.hex()
+    subprocess.run(["git", "show", "--stat", bootstrap])
     if not click.confirm(
         f"Do you want to verify the '{branch}' branch using "
         f"commit {bootstrap} as bootstrap?"


### PR DESCRIPTION
A minor help so the user can get a glimpse of what option is being proposed without having to copy-paste and cross-reference the commit hash manually.

Example, `bark_rules` bootstrap:

```
$ bark verify
commit f69ebbbcba4a2105e2459dde29022a21a7186c08 (bark_rules)
Author: Emil Lundberg <emil@yubico.com>
Date:   Wed Jan 24 17:40:09 2024 +0100

    Initial commit

    There will be many others

    But this one is first

 .bark/bark_rules.yaml   |   7 ++
 .bark/commit_rules.yaml |   5 +
 .bark/pubkeys/dain      | 551 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .bark/pubkeys/emil      | 852 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .bark/requirements.txt  |   1 +
 .gitattributes          |   9 ++
 .gitignore              |  26 +++++
 7 files changed, 1451 insertions(+)
The bootstrap commit (f69ebbbcba4a2105e2459dde29022a21a7186c08) of the bark_rules branch has not been verified!
Do you want to trust this commit as the bootstrap for bark? [y/N]: y
```

Same for the per-branch bootstrap:
```
$ bark protect
Configure how the 'bark_rules' branch should be validated!

commit f69ebbbcba4a2105e2459dde29022a21a7186c08 (HEAD -> bark_rules)
Author: Emil Lundberg <emil@yubico.com>
Date:   Wed Jan 24 17:40:09 2024 +0100

    Initial commit

    There will be many others

    But this one is first

 .bark/bark_rules.yaml   |   7 ++
 .bark/commit_rules.yaml |   5 +
 .bark/pubkeys/dain      | 551 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .bark/pubkeys/emil      | 852 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .bark/requirements.txt  |   1 +
 .gitattributes          |   9 ++
 .gitignore              |  26 +++++
 7 files changed, 1451 insertions(+)
Do you want to verify the 'bark_rules' branch using commit f69ebbbcba4a2105e2459dde29022a21a7186c08 as bootstrap? [y/N]:
```

