### PR TITLE
Remove trailing period from automated commit messages

### DIFF
--- a/gitbark/cli/__main__.py
+++ b/gitbark/cli/__main__.py
@@ -127,7 +127,7 @@ def add_rules(ctx):
     project = ctx.obj["project"]
     add_commit_rules_interactive(project)
     _confirm_commit(
-        commit_message="Modify commit rules (made by bark).",
+        commit_message="Modify commit rules (made by bark)",
         manual_action=(
             "The 'commit_rules.yaml' file has been staged. "
             "Please commit the changes!"
@@ -144,7 +144,7 @@ def add_modules(ctx):
     branch = project.repo.branch
     add_modules_interactive(project)
     _confirm_commit(
-        commit_message="Modify bark modules (made by bark).",
+        commit_message="Modify bark modules (made by bark)",
         manual_action=(
             "The 'bark_rules.yaml' file has been staged. Please commit the changes!"
         ),
@@ -166,7 +166,7 @@ def protect(ctx):
     branch = project.repo.branch
     add_branches_interactive(project, branch)
     _confirm_commit(
-        commit_message="Modify bark modules (made by bark).",
+        commit_message="Modify bark modules (made by bark)",
         manual_action=(
             "The 'bark_rules.yaml' file has been staged. Please commit the changes!"
         ),

--- a/gitbark/commands/setup.py
+++ b/gitbark/commands/setup.py
@@ -322,7 +322,7 @@ def setup(project: Project) -> None:
             content=yaml.safe_dump(asdict(bark_rules), sort_keys=False),
         )
 
-        _confirm_commit(commit_message="Add initial modules and rules (made by bark).")
+        _confirm_commit(commit_message="Add initial modules and rules (made by bark)")
 
     active_branch = get_active_branch(project)
     if active_branch:  # checkout if we have an active branch
@@ -332,12 +332,12 @@ def setup(project: Project) -> None:
 
     if not get_commit_rules(project):
         add_commit_rules_interactive(project)
-        _confirm_commit(commit_message="Initial rules (made by bark).")
+        _confirm_commit(commit_message="Initial rules (made by bark)")
 
     if branch != BARK_RULES_BRANCH and not branch_in_bark_rules_yaml(project, branch):
         cmd("git", "checkout", BARK_RULES_BRANCH)
         add_branches_interactive(project, branch)
-        _confirm_commit(f"Add {branch} to bark_rules (made by bark).")
+        _confirm_commit(f"Add {branch} to bark_rules (made by bark)")
         cmd(
             "git", "checkout", branch
         )  # run this if the commit was made in interactive mode


### PR DESCRIPTION
This is one of the commonly accepted guidelines for writing good commit messages. See for example these sources for reference:

- https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
- https://github.blog/2022-06-30-write-better-commits-build-better-projects/
- https://www.gitkraken.com/learn/git/best-practices/git-commit-message#quick-git-commit-message-tips
- https://www.theserverside.com/video/Follow-these-git-commit-message-guidelines